### PR TITLE
Github actions fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,17 +58,19 @@ jobs:
           mkdir -p mcr 
           pip3 install requests
           python3 gist_test_ctf.py --get --token=${{ secrets.GH_GIST_TOKEN }}
-          echo "hostDirectory=`pwd`" >> $GITHUB_ENV
+          echo "HOSTDIRECTORY=`pwd`" >> $GITHUB_ENV
           if which matlab; then
-            echo "matlabExecutable=`which matlab`" >> $GITHUB_ENV;
+            echo "MATLABEXECUTABLE=`which matlab`" >> $GITHUB_ENV;
           else
-            echo "matlabExecutable=`pwd`/mcr/bin/matlab" >> $GITHUB_ENV;
+            echo "MATLABEXECUTABLE=`pwd`/mcr/bin/matlab" >> $GITHUB_ENV;
           fi
       - name: Install Mac MCR
         if: ${{ matrix.variant.os == 'macos-12' && steps.cache-mcr.outputs.cache-hit != 'true' }}
         run: |
           unzip -d . -q test/pace_neutrons_installer.zip
           sudo ./pace_neutrons_installer/Contents/MacOS/setup -mode silent -agreeToLicense yes
+          sleep 10
+          while [[ ! -z $(ps aux |grep installer | grep mathworks) ]]; do sleep 10; done
           cp -r /Applications/MATLAB/MATLAB_Runtime/v98/* mcr/
       - name: Install Win MCR
         if: ${{ matrix.variant.os == 'windows-2022' && steps.cache-mcr.outputs.cache-hit != 'true' }}
@@ -82,8 +84,8 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.pyvariant.tag }}-${{ matrix.variant.tag }}
           CIBW_ENVIRONMENT: >-
-            matlabExecutable="${{ matrix.variant.mlprefix }}${{ env.matlabExecutable }}"
-            hostDirectory="${{ matrix.variant.mlprefix }}${{ env.hostDirectory }}"
+            MATLABEXECUTABLE="${{ matrix.variant.mlprefix }}${{ env.MATLABEXECUTABLE }}"
+            HOSTDIRECTORY="${{ matrix.variant.mlprefix }}${{ env.HOSTDIRECTORY }}"
           CIBW_BUILD_VERBOSITY: 1
           MACOSX_DEPLOYMENT_TARGET: "10.15"
       - name: Setup micromamba environment
@@ -98,9 +100,10 @@ jobs:
             numpy
             six
       - name: Install wheel and run test
-        if: ${{ matrix.variant.os != 'windows-2022' }}
+        if: ${{ matrix.variant.os != 'macos-12' }}
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
+            # On Windows, micromamba only sets up for powershell
             conda init
             source ~/.bashrc
             conda activate libpymcr-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,17 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          - {os: ubuntu-22.04, matlab-version: R2020a, tag: manylinux_x86_64, mlprefix: /host/, mltag: glnxa64, zpsuf: .zip}
-          - {os: macos-12, matlab-version: R2020a, tag: macosx_x86_64, mlprefix: '', mltag: maci64, zpsuf: .dmg.zip}
-          - {os: windows-2022, matlab-version: R2021a, tag: win_amd64, mlprefix: '', mltag: win64, zpsuf: .zip}
+          - {os: ubuntu-22.04, matlab-version: R2020a, tag: manylinux_x86_64, mlprefix: /host/,
+             mltag: glnxa64, zpsuf: .zip, python_shell: 'bash -l {0}'}
+          - {os: macos-12, matlab-version: R2020a, tag: macosx_x86_64, mlprefix: '',
+             mltag: maci64, zpsuf: .dmg.zip, python_shell: 'bash -l {0}'}
+          - {os: windows-2022, matlab-version: R2021a, tag: win_amd64, mlprefix: '',
+             mltag: win64, zpsuf: .zip, python_shell: 'powershell'}
         pyvariant:
           - {version: '3.8', tag: cp38}
     env:
       # MCRVER and MCRV must agree (R2020a is v98, R2022b is v913 etc)
       MCRVER: R2020a
-      MCRV: v98
-      MCRREL: 8
 
     steps:
       - uses: actions/checkout@v3
@@ -55,39 +56,27 @@ jobs:
       - name: Setup directories
         run: |
           mkdir -p mcr 
+          pip3 install requests
+          python3 gist_test_ctf.py --get --token=${{ secrets.GH_GIST_TOKEN }}
           echo "hostDirectory=`pwd`" >> $GITHUB_ENV
           if which matlab; then
             echo "matlabExecutable=`which matlab`" >> $GITHUB_ENV;
           else
             echo "matlabExecutable=`pwd`/mcr/bin/matlab" >> $GITHUB_ENV;
           fi
-          # It runs the git bash shell by default which might not have wget
-          if [[ "$OSTYPE" == "msys" ]]; then
-            echo "PATH=$PATH:/c/msys64/usr/bin" >> $GITHUB_ENV;
-          fi
-      - name: Download MCR
-        if: ${{ matrix.variant.os != 'ubuntu-22.04' && steps.cache-mcr.outputs.cache-hit != 'true' }}
-        run: |
-          SUBDIR=MATLAB_Runtime_${MCRVER}_Update_${MCRREL}_
-          URL_PREF=https://ssd.mathworks.com/supportfiles/downloads/${MCRVER}/Release/${MCRREL}/deployment_files/installer/complete/
-          wget --quiet ${URL_PREF}${{ matrix.variant.mltag }}/${SUBDIR}${{ matrix.variant.mltag }}${{ matrix.variant.zpsuf }}
       - name: Install Mac MCR
         if: ${{ matrix.variant.os == 'macos-12' && steps.cache-mcr.outputs.cache-hit != 'true' }}
         run: |
-          unzip -d . -q MATLAB_Runtime_${MCRVER}_Update_${MCRREL}_maci64.dmg.zip
-          hdiutil mount MATLAB_Runtime_${MCRVER}_Update_${MCRREL}_maci64.dmg
-          cp -R /Volumes/MATLAB_Runtime_${MCRVER}_Update_${MCRREL}_maci64 .
-          hdiutil unmount /Volumes/MATLAB_Runtime_${MCRVER}_Update_${MCRREL}_maci64
-          sudo ./MATLAB_Runtime_${MCRVER}_Update_${MCRREL}_maci64/InstallForMacOSX.app/Contents/MacOS/InstallForMacOSX -mode silent -agreeToLicense yes
-          cp -r /Applications/MATLAB/MATLAB_Runtime/${{ env.MCRV }}/* mcr/
+          unzip -d . -q test/pace_neutrons_installer.zip
+          sudo ./pace_neutrons_installer/Contents/MacOS/setup -mode silent -agreeToLicense yes
+          cp -r /Applications/MATLAB/MATLAB_Runtime/v98/* mcr/
       - name: Install Win MCR
         if: ${{ matrix.variant.os == 'windows-2022' && steps.cache-mcr.outputs.cache-hit != 'true' }}
         run: |
-          unzip -d . -q MATLAB_Runtime_${MCRVER}_Update_${MCRREL}_win64.zip
-          powershell -Command ".\setup.exe -mode silent -agreeToLicense yes"
+          powershell -Command "test\pace_neutrons_installer.exe -mode silent -agreeToLicense yes"
           sleep 10
-          powershell -Command "while(Get-Process setup_legacy -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 10 }"
-          cp -r /c/Program\ Files/MATLAB/MATLAB\ Runtime/${{ env.MCRV }}/* mcr/
+          powershell -Command "while(Get-Process pace_neutrons_installer -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 10 }"
+          cp -r /c/Program\ Files/MATLAB/MATLAB\ Runtime/v98/* mcr/
       - name: Build wheel
         uses: pypa/cibuildwheel@v2.12.0
         env:
@@ -108,11 +97,15 @@ jobs:
             python=${{ matrix.pyvariant.version }}
             numpy
             six
-            requests
       - name: Install wheel and run test
+        if: ${{ matrix.variant.os != 'windows-2022' }}
         run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            conda init
+            source ~/.bashrc
+            conda activate libpymcr-test
+          fi
           python -m pip install wheelhouse/*
-          python gist_test_ctf.py --get --token=${{ secrets.GH_GIST_TOKEN }}
           cd test
           python run_test.py
       - name: Setup tmate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,20 +100,17 @@ jobs:
             numpy
             six
       - name: Install wheel and run test
-        if: ${{ matrix.variant.os != 'macos-12' }}
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
             # On Windows, micromamba only sets up for powershell
-            conda init
-            source ~/.bashrc
-            conda activate libpymcr-test
+            eval "$($MAMBA_EXE shell activate libpymcr-test)"
           fi
           python -m pip install wheelhouse/*
           cd test
           python run_test.py
-      - name: Setup tmate
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+     #- name: Setup tmate
+     #  if: ${{ failure() }}
+     #  uses: mxschmitt/action-tmate@v3
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.variant.os }}_artifacts.zip

--- a/gist_test_ctf.py
+++ b/gist_test_ctf.py
@@ -43,8 +43,6 @@ def get_gist(token=None):
         response = requests.get(
             'https://api.github.com/gists/' + gid,
             headers=headers)
-        print(response.status_code)
-        print(response.text)
         assert response.status_code == 200, 'Could not download gist'
         jsout = json.loads(response.text) 
         for fname in jsout['files'].keys():

--- a/gist_test_ctf.py
+++ b/gist_test_ctf.py
@@ -1,7 +1,8 @@
 import argparse, requests, json, os, base64
 
-CTFFILES = ['test_R2020a.ctf', 'test_R2021a.ctf']
-GIST_ID = ['7389c37c89aed787c8a200c993fb67af', 'b595469518fbec7d9e293cf98bc123d6']
+FILES = ['test_R2020a.ctf', 'test_R2021a.ctf', 'pace_neutrons_installer.exe', 'pace_neutrons_installer.zip']
+GIST_ID = ['7389c37c89aed787c8a200c993fb67af', 'b595469518fbec7d9e293cf98bc123d6',
+           'd13ac4e315dc0e0b95506c2b8bb4ef2d', '6a1606ced1d38118ec0e8d230048f372']
 
 def main():
     parser = argparse.ArgumentParser()
@@ -43,6 +44,7 @@ def get_gist():
         assert response.status_code == 200, 'Could not download gist'
         jsout = json.loads(response.text) 
         for fname in jsout['files'].keys():
+            print(f'Downloading file {fname}')
             if jsout['files'][fname]['truncated'] == True:
                 response = requests.get(jsout['files'][fname]['raw_url'])
                 assert response.status_code == 200, 'Could not download gist'
@@ -58,13 +60,13 @@ def set_gist(token):
     assert token is not None, 'Need token for this action'
     headers={'Accept': 'application/vnd.github+json', 'Authorization': 'Bearer ' + token}
     for idx, gid in enumerate(GIST_ID):
-        path = os.path.join(os.path.dirname(__file__), 'test', CTFFILES[idx])
+        path = os.path.join(os.path.dirname(__file__), 'test', FILES[idx])
         with open(path, 'rb') as f:
             contents = base64.b85encode(f.read()).decode('ascii')
         response = requests.patch(
             'https://api.github.com/gists/' + gid,
             headers=headers,
-            data=json.dumps({'files':{CTFFILES[idx]:{'content':contents}}}))
+            data=json.dumps({'files':{FILES[idx]:{'content':contents}}}))
         if response.status_code != 200:
             raise RuntimeError('Could not update gist')
 
@@ -73,7 +75,7 @@ def create_gist(token):
     assert token is not None, 'Need token for this action'
     headers = {'Accept': 'application/vnd.github+json', 'Authorization': 'Bearer ' + token}
     data0 = {'description': 'b85 encoded ctf for testing libpymcr', 'public': True}
-    for ctf in CTFFILES:
+    for ctf in FILES:
         path = os.path.join(os.path.dirname(__file__), 'test', ctf)
         with open(path, 'rb') as f:
             contents = base64.b85encode(f.read()).decode('ascii')

--- a/gist_test_ctf.py
+++ b/gist_test_ctf.py
@@ -20,7 +20,7 @@ def main():
         raise RuntimeError('One of the options --set, --get or --create must be specified')
 
     if args.get:
-        get_gist()
+        get_gist(token)
     elif args.set:
         set_gist(token)
     else:
@@ -35,12 +35,16 @@ def list_gist(token):
     resp = json.loads(response.text)
 
 
-def get_gist():
+def get_gist(token=None):
     headers={'Accept': 'application/vnd.github+json'}
+    if token is not None:
+        headers = {'Authorization': 'Bearer ' + token, **headers}
     for gid in GIST_ID:
         response = requests.get(
             'https://api.github.com/gists/' + gid,
             headers=headers)
+        print(response.status_code)
+        print(response.text)
         assert response.status_code == 200, 'Could not download gist'
         jsout = json.loads(response.text) 
         for fname in jsout['files'].keys():

--- a/libpymcr/utils.py
+++ b/libpymcr/utils.py
@@ -79,6 +79,7 @@ class DetectMatlab(object):
             raise RuntimeError(f'Operating system {self.system} is not supported.')
 
     def find_version(self, root_dir):
+        print(f'Searching for Matlab in {root_dir}')
         def find_file(path, filename, max_depth=3):
             """ Finds a file, will return first match"""
             for depth in range(max_depth + 1):

--- a/libpymcr/utils.py
+++ b/libpymcr/utils.py
@@ -110,8 +110,13 @@ class DetectMatlab(object):
                    'Darwin': ['/Applications/MATLAB', '/Applications/']}
         if self.system == 'Windows':
             mlPath += get_matlab_from_registry(self.ver) + GUESSES['Windows']
-        if 'matlabExecutable' in os.environ: # Running in CI
-            mlPath += os.path.abspath(os.path.join(os.environ['matlabExecutable'], '..', '..'))
+        if 'MATLABEXECUTABLE' in os.environ: # Running in CI
+            ml_env = os.environ['MATLABEXECUTABLE']
+            if self.system == 'Windows' and ':' not in ml_env:
+                pp = ml_env.split('/')[1:]
+                ml_env = pp[0] + ':\\' + '\\'.join(pp[1:])
+            mlPath += [os.path.abspath(os.path.join(ml_env, '..', '..'))]
+            print(f'mlPath={mlPath}')
         for possible_dir in mlPath + GUESSES[self.system]:
             if os.path.isdir(possible_dir):
                 rv = self.find_version(possible_dir)

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,6 @@ class CMakeBuild(build_ext):
             if is_vsc():
                 pp = ml_env.split('/')[1:]
                 ml_env = pp[0] + ':\\' + '\\'.join(pp[1:])
-            print(ml_env)
             matlab_path = str(pathlib.Path(ml_env).resolve().parents[1])
             if ml_env.startswith('/host') and not matlab_path.startswith('/host'):
                 matlab_path = '/host/' + matlab_path
@@ -169,6 +168,5 @@ else:
         if is_vsc():
             pp = outdir.split('/')[1:]
             outdir = pp[0] + ':\\' + '\\'.join(pp[1:])
-            print(outdir)
         for mex in glob.glob('**/call_python*.mex*', recursive=True):
             shutil.copy(mex, outdir)

--- a/setup.py
+++ b/setup.py
@@ -100,9 +100,14 @@ class CMakeBuild(build_ext):
         env['CXXFLAGS'] = cxxflags
         if 'MATLAB_DIR' in env:
             cmake_args += ['-DMatlab_ROOT_DIR=' + env['MATLAB_DIR']]
-        elif 'matlabExecutable' in env:
-            matlab_path = str(pathlib.Path(env['matlabExecutable']).resolve().parents[1])
-            if env['matlabExecutable'].startswith('/host') and not matlab_path.startswith('/host'):
+        elif 'MATLABEXECUTABLE' in env:
+            ml_env = env['MATLABEXECUTABLE']
+            if is_vsc():
+                pp = ml_env.split('/')[1:]
+                ml_env = pp[0] + ':\\' + '\\'.join(pp[1:])
+            print(ml_env)
+            matlab_path = str(pathlib.Path(ml_env).resolve().parents[1])
+            if ml_env.startswith('/host') and not matlab_path.startswith('/host'):
                 matlab_path = '/host/' + matlab_path
             cmake_args += ['-DMatlab_ROOT_DIR=' + matlab_path]
             if is_osx():
@@ -157,10 +162,10 @@ try:
 except CalledProcessError:
     print("Failed to build the extension!")
 else:
-    if 'matlabExecutable' in os.environ and 'hostDirectory' in os.environ:
+    if 'MATLABEXECUTABLE' in os.environ and 'HOSTDIRECTORY' in os.environ:
         # Running in CI, copy mex file out
         import shutil, glob
-        outdir = os.environ['hostDirectory']
+        outdir = os.environ['HOSTDIRECTORY']
         if is_vsc():
             pp = outdir.split('/')[1:]
             outdir = pp[0] + ':\\' + '\\'.join(pp[1:])

--- a/src/matlab.cmake
+++ b/src/matlab.cmake
@@ -1,6 +1,6 @@
 # You can set a specific Matlab version folder here
-#set(Matlab_ROOT_DIR "c:/Program Files/MATLAB/R2020a")
-#set(MATLAB_FIND_DEBUG 1)
+#set(Matlab_ROOT_DIR "d:/MATLAB/Matlab Runtime/v910")
+set(MATLAB_FIND_DEBUG 1)
 find_package(Matlab)
 
 if (NOT Matlab_INCLUDE_DIRS)

--- a/src/matlab.cmake
+++ b/src/matlab.cmake
@@ -1,6 +1,6 @@
 # You can set a specific Matlab version folder here
 #set(Matlab_ROOT_DIR "d:/MATLAB/Matlab Runtime/v910")
-set(MATLAB_FIND_DEBUG 1)
+#set(MATLAB_FIND_DEBUG 1)
 find_package(Matlab)
 
 if (NOT Matlab_INCLUDE_DIRS)


### PR DESCRIPTION
Change to using own installer (created from [this code](https://github.com/pace-neutrons/pace-python/blob/main/installer/make_package.m)) which only includes the core, numerics and python packages. This should keep the MCR installed folder at around 3GB per OS, so will be under the 10GB limit for the github actions cache.