### PR TITLE
RELEASE 0.1.5

### DIFF
--- a/libpymcr/Matlab.py
+++ b/libpymcr/Matlab.py
@@ -52,9 +52,9 @@ class NamespaceWrapper(object):
         if nargout is None:
             mnargout, undetermined = self._interface.call('getArgOut', self._name, nargout=2)
             if not undetermined:
-                nargout = max(min(int(mnargout), nreturn), 1)
+                nargout = min(int(mnargout), nreturn)
             else:
-                nargout = max(nreturn, 1)
+                nargout = nreturn
         args += sum(kwargs.items(), ())
         args = unwrap(args, self._interface)
         return wrap(self._interface.call(self._name, *args, nargout=nargout), self._interface)

--- a/libpymcr/utils.py
+++ b/libpymcr/utils.py
@@ -13,7 +13,7 @@ def get_nlhs():
     if '=' in caller and '(' in caller and caller.index('=') < caller.index('('):
         return len(caller.split('=')[0].split(','))
     else:
-        return 1
+        return 0
 
 
 def get_version_from_ctf(ctffile):

--- a/src/call.m
+++ b/src/call.m
@@ -113,12 +113,12 @@ function [n, undetermined] = getArgOut(name, parent)
             try
                 n = nargout(name);
             catch
-                n = 1;
+                n = 0;
                 undetermined = true;
             end
         end
     else
-        n = 1;
+        n = 0;
         undetermined = true;
     end
 end

--- a/src/type_converter.cpp
+++ b/src/type_converter.cpp
@@ -259,8 +259,8 @@ template <typename T> Array pymat_converter::raw_to_matlab(char *raw, size_t sz,
         // but (see: https://www.mathworks.com/matlabcentral/answers/514456) this causes an issue
         // when Matlab tries to delete the buffer. So we have to use a hack (see release_buffer() below)
         buffer_ptr_t<T> buf = buffer_ptr_t<T>(begin, [](void* ptr){});
-        if (m_numpy_conv_flag == NumpyConversion::COPY) {
-            // But if user specify to copy, then use the prescribed API with createBuffer()
+        if (m_numpy_conv_flag == NumpyConversion::COPY || sz < 1000) {
+            // But if user specify to copy or for small arrays, then use the prescribed API with createBuffer()
             buf = factory.createBuffer<T>(sz);
             memcpy(buf.get(), begin, sz * sizeof(T));
         }
@@ -269,7 +269,7 @@ template <typename T> Array pymat_converter::raw_to_matlab(char *raw, size_t sz,
         } else {
             rv = factory.createArrayFromBuffer(dims, std::move(buf), MemoryLayout::ROW_MAJOR);
         }
-        if (m_numpy_conv_flag == NumpyConversion::WRAP) {
+        if (m_numpy_conv_flag == NumpyConversion::WRAP && sz >= 1000) {
             // For wrapped arrays, we store a shared-data copy in a cache in this object to prevent Matlab
             // from deleting it before we are ready to release the buffer.
             if (m_mex_flag) {

--- a/src/type_converter.cpp
+++ b/src/type_converter.cpp
@@ -417,7 +417,7 @@ StructArray pymat_converter::python_dict_to_matlab(PyObject *result, matlab::dat
     return retval;
 }
 
-int _listtuple_array_data(PyObject *result, std::vector<double> &data, std::vector<size_t> &dims, bool is_first=false) {
+int _list_array_data(PyObject *result, std::vector<double> &data, std::vector<size_t> &dims, bool is_first=false) {
     size_t obj_size = PyTuple_Check(result) ? (size_t)PyTuple_Size(result) : (size_t)PyList_Size(result);
     bool is_tuple = false;
     int dim, dim0;
@@ -431,10 +431,10 @@ int _listtuple_array_data(PyObject *result, std::vector<double> &data, std::vect
                 // The first call (from listtuple_to_cell) will set is_first to true
                 // Subsequent recursive calls will set this to true only on first iteration and
                 // also when it in turn has been called by the first iteration of the outer loop.
-                if ((dim0 = _listtuple_array_data(item, data, dims, (ii==0) & is_first)) < 0) {
+                if ((dim0 = _list_array_data(item, data, dims, (ii==0) & is_first)) < 0) {
                     return -1; }
             } else {
-                if ((dim = _listtuple_array_data(item, data, dims)) < 0 || dim != dim0) {
+                if ((dim = _list_array_data(item, data, dims)) < 0 || dim != dim0) {
                     return -1; }
             }
             is_tuple = true;
@@ -477,19 +477,21 @@ Array pymat_converter::listtuple_to_cell(PyObject *result, matlab::data::ArrayFa
     // Try to see if we have a nested list/tuple of numeric types: construct a Matlab N-D array
     std::vector<size_t> arr_dim;
     std::vector<double> arr_data;
-    if (_listtuple_array_data(result, arr_data, arr_dim, true) > 0) {
+    bool is_tuple = PyTuple_Check(result);
+    if (!is_tuple && _list_array_data(result, arr_data, arr_dim, true) > 0) {
+        // Only convert nested lists to Matlab arrays, leave tuples as cells
         if (arr_dim.size() > 1) {
             arr_data = _to_colmajor(arr_data, arr_dim);  // Convert to column-major (req by Matlab)
         } else {
             arr_dim.insert(arr_dim.begin(), 1); } // Force row vector for consistency ([1 2 3] is row vector in ml)
         return factory.createArray<typename std::vector<double>::iterator, double>(arr_dim, arr_data.begin(), arr_data.end());
     }
-    size_t obj_size = PyTuple_Check(result) ? (size_t)PyTuple_Size(result) : (size_t)PyList_Size(result);
+    size_t obj_size = is_tuple ? (size_t)PyTuple_Size(result) : (size_t)PyList_Size(result);
     CellArray cell_out = factory.createCellArray({1, obj_size});
     std::vector<PyObject*> objs;
-    int typeflags = 0;
+    int typeflags = is_tuple ? MYOTHER : 0;  // Only create vector from lists not tuples
     for(size_t ii=0; ii<obj_size; ii++) {
-        PyObject *item = PyTuple_Check(result) ? PyTuple_GetItem(result, ii) : PyList_GetItem(result, ii);
+        PyObject *item = is_tuple ? PyTuple_GetItem(result, ii) : PyList_GetItem(result, ii);
         cell_out[0][ii] = python_to_matlab_single(item, factory);
         if (PyLong_Check(item)) {
             // Force conversion to double because Matlab defaults to this and many routines will error with int64


### PR DESCRIPTION
Bugfixes for Release 0.1.5

* Workaround to fix a segfault when temporary numpy arrays are re-used multiple times in definition of SpinW objects.
* Change behaviour of tuples and lists. Python tuples now always convert to Matlab cells. Nested lists will convert to Matlab numeric arrays if they are consistent in shape and contain only numbers. This allows Python `([1,2,3], [4,5,6])` to convert to Matlab `{[1 2 3] [4 5 6]}` whereas before it would have converted to Matlab `[1 2 3; 4 5 6]`. Python `[[1,2,3], [4,5,6]]` will still convert to Matlab `[1 2 3; 4 5 6]`.
* Fix bug where Matlab commands which return zero outputs fail, e.g. `m.axis([0,1,0,1])` due to incorrectly given `nargout` in Matlab.py / call.m
