### PR TITLE
RELEASE v0.1.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,20 +61,20 @@ jobs:
         os: [ubuntu-22.04, windows-2022, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Cache MCR
         if: ${{ matrix.os != 'ubuntu-22.04' }}
         id: cache-mcr
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: mcr
           key: ${{ runner.os }}-matlab-${{ env.MCRVER }}-mcr
           lookup-only: true
       - name: Cache gists
         id: cache-gists
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: gists
           key: ${{ runner.os }}-gists
@@ -112,7 +112,7 @@ jobs:
         os: [ubuntu-22.04, windows-2022, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup variables
@@ -143,18 +143,18 @@ jobs:
         uses: matlab-actions/setup-matlab@v1.2.4
         with:
           release: ${{ env.MLVER }}
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         if: ${{ matrix.os != 'ubuntu-22.04' }}
         with:
           path: mcr
           key: ${{ runner.os }}-matlab-${{ env.MCRVER }}-mcr
           fail-on-cache-miss: true
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: gists
           key: ${{ runner.os }}-gists
           fail-on-cache-miss: true
-      - uses: pypa/cibuildwheel@v2.12.0
+      - uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_BUILD: ${{ env.CIBW }}
           CIBW_ENVIRONMENT: >-
@@ -162,9 +162,8 @@ jobs:
             HOSTDIRECTORY="${{ env.MLPREFIX }}${{ env.HOSTDIRECTORY }}"
           CIBW_BUILD_VERBOSITY: 1
           MACOSX_DEPLOYMENT_TARGET: "10.15"
-      - uses: mamba-org/provision-with-micromamba@main
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: false
           cache-downloads: true
       - name: Install wheels and run test
         run: |
@@ -176,7 +175,9 @@ jobs:
             eval "$($MAMBA_EXE shell activate py$pyver)"
             python -m pip install wheelhouse/*cp$(echo $pyver | sed s/\\.//)*
             cd test
-            python run_test.py
+            # Sometimes the test results in a segfault on exit
+            python run_test.py || true
+            test -f success
             cd ..
           done
       - name: Upload release wheels
@@ -187,7 +188,7 @@ jobs:
       #- name: Setup tmate
       #  if: ${{ failure() }}
       #  uses: mxschmitt/action-tmate@v3
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}_artifacts.zip
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [v0.1.6](https://github.com/pace-neutrons/libpymcr/compare/v0.1.5...v0.1.6)
+
+## Bugfixes
+
+Bugfixes for various user reported issues when used with pace-python and PySpinW.
+
+* Add search of `matlab` executable on path for Linux.
+* Add a `type` method to interrogate Matlab type (fixes issue with [pace-python-demo example](https://github.com/pace-neutrons/pace-python-demo/blob/main/demo.py#L86))
+* Add a proxy to allow plain struct properties of a class to be manipulated like in Matlab (so `class.prop.subprop = 1` will work if `class.prop` is a plain Matlab `struct`).
+* Change to using `evalAsync` in Matlab and as part of this polls the output streams every 1ms and prints output to Python - this allows synchronous output to both console, Jupyter and Spyder without additional code.
+
+
 # [v0.1.5](https://github.com/pace-neutrons/libpymcr/compare/v0.1.4...v0.1.5)
 
 ## Bugfixes for PySpinW

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
     given-names: "Gregory S."
     orcid: https://orcid.org/0000-0002-2787-8054
 title: "libpymcr"
-version: "0.1.5"
-date-released: "2023-03-24"
+version: "0.1.6"
+date-released: "2024-04-26"
 license: "GPL-3.0-only"
 repository: "https://github.com/pace-neutrons/libpymcr"
 url: "https://github.com/pace-neutrons/libpymcr"

--- a/libpymcr/Matlab.py
+++ b/libpymcr/Matlab.py
@@ -103,6 +103,12 @@ class Matlab(object):
         """
         return NamespaceWrapper(self._interface, name)
 
+    def type(self, obj):
+        if hasattr(obj, 'handle'):
+            return self._interface.call('class', obj.handle, nargout=1)
+        else:
+            return str(type(obj))
+
     def get_matlab_functions(self):
         """
         Returns a list of public functions in this CTF archive

--- a/libpymcr/utils.py
+++ b/libpymcr/utils.py
@@ -234,7 +234,7 @@ class DetectMatlab(object):
     def guess_from_syspath(self):
         matlab_exe = shutil.which('matlab')
         if matlab_exe is None:
-            return None if self.system == 'Windows' else guess_from_env('PATH')
+            return None if self.system == 'Windows' else self.guess_from_env('PATH')
         mlbinpath = os.path.dirname(os.path.realpath(matlab_exe))
         return self.find_version(os.path.abspath(os.path.join(mlbinpath, '..')))
 

--- a/libpymcr/utils.py
+++ b/libpymcr/utils.py
@@ -7,6 +7,7 @@ import ast
 import inspect
 import dis
 import linecache
+import shutil
 from pathlib import Path
 
 
@@ -22,6 +23,8 @@ OPERATOR_NAMES = {
     "CALL_FUNCTION_EX", "LOAD_METHOD", "CALL_METHOD", "DICT_MERGE", "DICT_UPDATE", "LIST_EXTEND",
 }
 
+MLVERDIC = {f'R{rv[0]}{rv[1]}':f'9.{vr}' for rv, vr in zip([[yr, ab] for yr in range(2017,2023) for ab in ['a', 'b']], range(2, 14))}
+MLVERDIC.update({'R2023a':'9.14', 'R2023b':'23.2'})
 
 def get_nret_from_dis(frame):
     # Tries to get the number of return values for a function
@@ -164,8 +167,18 @@ class DetectMatlab(object):
         else:
             raise RuntimeError(f'Operating system {self.system} is not supported.')
 
+    @property
+    def ver(self):
+        return self._ver
+
+    @ver.setter
+    def ver(self, val):
+        self._ver = str(val)
+        if self._ver.startswith('R') and self._ver in MLVERDIC.keys():
+            self._ver = MLVERDIC[self._ver]
+
     def find_version(self, root_dir):
-        print(f'Searching for Matlab in {root_dir}')
+        print(f'Searching for Matlab {self.ver} in {root_dir}')
         def find_file(path, filename, max_depth=3):
             """ Finds a file, will return first match"""
             for depth in range(max_depth + 1):
@@ -202,7 +215,6 @@ class DetectMatlab(object):
                 pp = ml_env.split('/')[1:]
                 ml_env = pp[0] + ':\\' + '\\'.join(pp[1:])
             mlPath += [os.path.abspath(os.path.join(ml_env, '..', '..'))]
-            print(f'mlPath={mlPath}')
         for possible_dir in mlPath + GUESSES[self.system]:
             if os.path.isdir(possible_dir):
                 rv = self.find_version(possible_dir)
@@ -210,13 +222,21 @@ class DetectMatlab(object):
                    return rv
         return None
 
-    def guess_from_env(self):
-        ld_path = os.getenv(self.path_var)
+    def guess_from_env(self, ld_path=None):
+        if ld_path is None:
+            ld_path = os.getenv(self.path_var)
         if ld_path is None: return None
         for possible_dir in ld_path.split(self.sep):
             if os.path.exists(os.path.join(possible_dir, self.file_to_find)):
                 return os.path.abspath(os.path.join(possible_dir, '..', '..'))
         return None
+
+    def guess_from_syspath(self):
+        matlab_exe = shutil.which('matlab')
+        if matlab_exe is None:
+            return None if self.system == 'Windows' else guess_from_env('PATH')
+        mlbinpath = os.path.dirname(os.path.realpath(matlab_exe))
+        return self.find_version(os.path.abspath(os.path.join(mlbinpath, '..')))
 
     def env_not_set(self):
         # Determines if the environment variables required by the MCR are set
@@ -242,7 +262,7 @@ class DetectMatlab(object):
         return None
 
 
-def checkPath(runtime_version, mlPath=None):
+def checkPath(runtime_version, mlPath=None, error_if_not_found=True):
     """
     Sets the environmental variables for Win, Mac, Linux
 
@@ -261,13 +281,15 @@ def checkPath(runtime_version, mlPath=None):
     else:
         mlPath = obj.guess_from_env()
         if mlPath is None:
+            mlPath = obj.guess_from_syspath()
+        if mlPath is None:
             mlPath = obj.guess_path()
-            if mlPath is None:
-                raise RuntimeError('Cannot find Matlab')
-            else:
+            if mlPath is not None:
                 ld_path = obj.sep.join([os.path.join(mlPath, sub, obj.arch) for sub in obj.required_dirs])
                 os.environ[obj.path_var] = ld_path
                 #print('Set ' + os.environ.get(obj.path_var))
+            elif error_if_not_found:
+                raise RuntimeError('Cannot find Matlab')
         #else:
         #    print('Found: ' + os.environ.get(obj.path_var))
 

--- a/src/libpymcr.cpp
+++ b/src/libpymcr.cpp
@@ -1,5 +1,7 @@
 #include "load_matlab.hpp"
 #include "libpymcr.hpp"
+#include <chrono>
+#include <ratio>
 #include <pybind11/stl.h>
 
 namespace libpymcr {
@@ -24,6 +26,15 @@ namespace libpymcr {
         return nargout;
     }
 
+    template <class T> T evalloop(matlab::cpplib::FutureResult<T> resAsync) {
+        std::chrono::duration<int, std::milli> period(1);
+        std::future_status status = resAsync.wait_for(std::chrono::duration<int, std::milli>(1));
+        while (status != std::future_status::ready) {
+            status = resAsync.wait_for(period);
+        }
+        return resAsync.get();
+    }
+
     py::object matlab_env::feval(const std::u16string &funcname, py::args args, py::kwargs& kwargs) {
         // Calls Matlab function
         const size_t nlhs = 0;
@@ -38,12 +49,12 @@ namespace libpymcr {
         py::gil_scoped_release gil_release;
         if (nargout == 1) {
             if (m_args.size() == 1) {
-                outputs.push_back(_lib->feval(funcname, m_args[0], _m_output_buf, _m_error_buf));
+                outputs.push_back(evalloop(_lib->fevalAsync(funcname, m_args[0], _m_output_buf, _m_error_buf)));
             } else {
-                outputs.push_back(_lib->feval(funcname, m_args, _m_output_buf, _m_error_buf));
+                outputs.push_back(evalloop(_lib->fevalAsync(funcname, m_args, _m_output_buf, _m_error_buf)));
             }
         } else {
-            outputs = _lib->feval(funcname, nargout, m_args, _m_output_buf, _m_error_buf);
+            outputs = evalloop(_lib->fevalAsync(funcname, nargout, m_args, _m_output_buf, _m_error_buf));
         }
         // Re-aquire the GIL
         py::gil_scoped_acquire gil_acquire;

--- a/src/libpymcr.hpp
+++ b/src/libpymcr.hpp
@@ -22,6 +22,7 @@ namespace libpymcr {
         std::shared_ptr<StreamBuffer> _m_error_buf = std::static_pointer_cast<StreamBuffer>(_m_error);
         pymat_converter _converter;
         size_t _parse_inputs(std::vector<matlab::data::Array>& m_args, py::args py_args, py::kwargs& py_kwargs);
+        template <class T> T evalloop(matlab::cpplib::FutureResult<T> resAsync);
     public:
         py::object feval(const std::u16string &funcname, py::args args, py::kwargs& kwargs);
         py::object call(py::args args, py::kwargs& kwargs);

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -3,17 +3,25 @@ import unittest
 import numpy as np
 import os, sys
 
+_VERSION_DIR = os.path.abspath(os.path.dirname(__file__))
+_VERSIONS = []
+for file in os.scandir(_VERSION_DIR):
+    if file.is_file() and file.name.startswith('test_R') and file.name.endswith('.ctf'):
+        _VERSIONS.append({'file': os.path.join(_VERSION_DIR, file.name),
+                          'version': file.name.split('test_')[1].split('.')[0]
+                          })
+
 class PacePythonTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         import libpymcr
-        try:
-            libpymcr.utils.checkPath('9.8')
-        except RuntimeError:
-            cls.m = libpymcr.Matlab(os.path.join(os.path.dirname(__file__), 'test_R2021a.ctf'))
-        else:
-            cls.m = libpymcr.Matlab(os.path.join(os.path.dirname(__file__), 'test_R2020a.ctf'))
+        for ver in _VERSIONS:
+            mlPath = libpymcr.utils.checkPath(ver['version'], error_if_not_found=False)
+            if mlPath is not None:
+                cls.m = libpymcr.Matlab(ver['file'], mlPath)
+                return
+        raise RuntimeError('Could not find a valid Matlab version')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Bugfixes for various user reported issues when used with [pace-python](https://github.com/pace-neutrons/pace-python) and [pyspinw](https://github.com/spinw/spinw).

* Add search of `matlab` executable on path for Linux. Fixes pace-neutrons/pace-python#30
* Add a `type` method to interrogate Matlab type (fixes issue with [pace-python-demo example](https://github.com/pace-neutrons/pace-python-demo/blob/main/demo.py#L86))
* Add a proxy to allow plain struct properties of a class to be manipulated like in Matlab (so `class.prop.subprop = 1` will work if `class.prop` is a plain Matlab `struct`). Fixes spinw/spinw#171
* Change to using `evalAsync` in Matlab and as part of this polls the output streams every 1ms and prints output to Python - this allows synchronous output to both console, Jupyter and Spyder without additional code. Fixes spinw/spinw#178