### PR TITLE
RELEASE v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [v0.1.8](https://github.com/pace-neutrons/libpymcr/compare/v0.1.7...v0.1.8)
+
+## Bugfixes
+
+* Implements a workaround for a changed `mxArray` layout in R2023b and newer (disables wrapping of Matlab arrays in Python).
+* Fixes issues with inline plots in Jupyter notebooks
+* Fix an issue with errors for Matlab functions which do not return any values, and an issue with recursive dot indexing
+
 # [v0.1.7](https://github.com/pace-neutrons/libpymcr/compare/v0.1.6...v0.1.7)
 
 ## New Features

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ authors:
     given-names: "Gregory S."
     orcid: https://orcid.org/0000-0002-2787-8054
 title: "libpymcr"
-version: "0.1.7"
+version: "0.1.8"
 date-released: "2024-04-26"
 license: "GPL-3.0-only"
 repository: "https://github.com/pace-neutrons/libpymcr"

--- a/libpymcr/MatlabProxyObject.py
+++ b/libpymcr/MatlabProxyObject.py
@@ -102,9 +102,8 @@ class matlab_method:
         self.method = method
 
     def __call__(self, *args, **kwargs):
-        nreturn = get_nlhs(self.method)
+        nreturn = max(get_nlhs(self.method), 1)
         nargout = int(kwargs.pop('nargout') if 'nargout' in kwargs.keys() else nreturn)
-        nargout = max(min(nargout, nreturn), 1)
         ifc = self.proxy.interface
         # serialize keyword arguments:
         args += sum(kwargs.items(), ())
@@ -189,7 +188,7 @@ class MatlabProxyObject(object):
             return matlab_method(self, name)
 
     def __setattr__(self, name, value):
-        self.interface.call('subsasgn', self.handle, {'type':'.', 'subs':name}, value)
+        self.interface.call('subsasgn', self.handle, {'type':'.', 'subs':name}, unwrap(value, self.interface))
 
     def __repr__(self):
         return "<proxy for Matlab {} object>".format(self.interface.call('class', self.handle))

--- a/src/libpymcr.cpp
+++ b/src/libpymcr.cpp
@@ -106,7 +106,7 @@ namespace libpymcr {
         // Specify MATLAB startup options
         _app = matlab::cpplib::initMATLABApplication(mode, options);
         _lib = matlab::cpplib::initMATLABLibrary(_app, ctfname);
-        _converter = pymat_converter(pymat_converter::NumpyConversion::WRAP);
+        _converter = pymat_converter(pymat_converter::NumpyConversion::COPY);
     }
 
 

--- a/src/type_converter.cpp
+++ b/src/type_converter.cpp
@@ -57,14 +57,16 @@ void* _get_data_pointer(matlab::data::Array arr) {
 // Wraps a Matlab array in a numpy array without copying (should work with all numeric types)
 template <typename T> PyObject* pymat_converter::matlab_to_python_t (matlab::data::Array arr, dt<T>) {
     // First checks if the array is not constructed from numpy data in the first place
-    PyObject* wrapper = is_wrapped_np_data(_get_data_pointer(arr));
-    if (wrapper != nullptr) {
-        // If so, just return the original numpy array, but need to INCREF it as returning new reference
-        if (!m_mex_flag) {
-            // For case where an np array is created in a mex file, its REFCNT was INC in the cache
-            Py_INCREF(wrapper);
+    if (m_numpy_conv_flag == NumpyConversion::WRAP) {
+        PyObject* wrapper = is_wrapped_np_data(_get_data_pointer(arr));
+        if (wrapper != nullptr) {
+            // If so, just return the original numpy array, but need to INCREF it as returning new reference
+            if (!m_mex_flag) {
+                // For case where an np array is created in a mex file, its REFCNT was INC in the cache
+                Py_INCREF(wrapper);
+            }
+            return wrapper;
         }
-        return wrapper;
     }
     std::vector<size_t> strides = {sizeof(T)};
     std::vector<size_t> dims = arr.getDimensions();


### PR DESCRIPTION
Bugfix release for ICM:

* Implements a workaround for a changed `mxArray` layout in R2023b and newer (disables wrapping of Matlab arrays in Python).
* Fixes issues with inline plots in Jupyter notebooks
* Fix an issue with errors for Matlab functions which do not return any values, and an issue with recursive dot indexing

