### PR TITLE
Add support for mac-13 / mac-14 in gh-actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       py_version:
         type: choice
-        options: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        options: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 concurrency :
   group: ${{ github.workflow }}-${{ github.ref == 'refs/head/main' && github.run_number || github.ref }}
@@ -27,9 +27,9 @@ env:
   JSONSTR: |
     {
       "pyvers": {
-        "push": ["3.8"],
-        "pull_request": ["3.8"],
-        "release": ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+        "push": ["3.8", "3.13"],
+        "pull_request": ["3.8", "3.13"],
+        "release": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
         "workflow_dispatch": ["WORKFLOW_PYVER"]
       },
       "os_map": {
@@ -64,7 +64,7 @@ jobs:
     # OS strategy matrix must match key in JSONSTR.os_map above
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-13]
+        os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -106,12 +106,14 @@ jobs:
           mkdir -p gists
           python gist_test_ctf.py --get --token=${{ secrets.GH_GIST_TOKEN }} --dir gists
       - uses: pypa/cibuildwheel@v2.22.0
+        if: ${{ matrix.os != 'macos-14' }}  # cibuildwheel builds x86_64 on macos-14!!
         env:
           CIBW_BUILD: ${{ env.CIBW }}
           CIBW_ENVIRONMENT: >-
             MATLABEXECUTABLE="${{ env.MLPREFIX }}${{ env.MATLABEXECUTABLE }}"
             HOSTDIRECTORY="${{ env.MLPREFIX }}${{ env.HOSTDIRECTORY }}"
           CIBW_BUILD_VERBOSITY: 1
+          MACOSX_DEPLOYMENT_TARGET: "11"
       - name: Install wheels and run test
         run: |
           # set -e makes sure the script fails if any command in the loop fails
@@ -120,7 +122,14 @@ jobs:
           for pyver in $(echo $PYVERS | sed s/[\"\']//g); do
             $MAMBA_EXE create -n py$pyver -c conda-forge python=$pyver numpy six requests
             eval "$($MAMBA_EXE shell activate py$pyver)"
-            python -m pip install wheelhouse/*cp$(echo $pyver | sed s/\\.//)*
+            pytag="cp$(echo $pyver | sed s/\\.//)"
+            if [[ $OSTYPE == "darwin23" ]]; then
+              echo "Compiling package for MacOS-14"
+              python -m pip install delocate
+              python -m pip wheel . --wheel-dir=dist --no-deps -v
+              delocate-wheel --require-archs arm64 -w wheelhouse -v dist/*${pytag}*
+            fi
+            python -m pip install wheelhouse/*${pytag}*
             cd test
             # Sometimes the test results in a segfault on exit
             python run_test.py || true
@@ -132,9 +141,9 @@ jobs:
         run: |
           eval "$($MAMBA_EXE shell activate gistsenv)"
           python release.py --notest --github --token=${{ secrets.GH_GIST_TOKEN }}
-      - name: Setup tmate
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+      #- name: Setup tmate
+      #  if: ${{ failure() }}
+      #  uses: mxschmitt/action-tmate@v3
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}_artifacts.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,88 +33,38 @@ env:
         "workflow_dispatch": ["WORKFLOW_PYVER"]
       },
       "os_map": {
-        "ubuntu-22.04": {
-          "mlver": "R2020a",
+        "ubuntu-24.04": {
+          "mlver": "R2024a",
           "tag": "manylinux_x86_64",
           "mlprefix": "/host/"
         },
         "windows-2022": {
-          "mlver": "R2021a",
+          "mlver": "R2024a",
           "tag": "win_amd64",
           "mlprefix": ""
         },
         "macos-13": {
-          "mlver": "R2020a",
+          "mlver": "R2024a",
           "tag": "macosx_x86_64",
           "mlprefix": ""
         },
         "macos-14": {
-          "mlver": "R2020a",
+          "mlver": "R2024a",
           "tag": "macosx_arm64",
           "mlprefix": ""
         }
       }
     }
   # Must match what is stored in the gists
-  MCRVER: R2020a
+  MCRVER: R2024a
 
 jobs:
-  cache_matlab:
-    name: Create Matlab cache, ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04, windows-2022, macos-13, macos-14]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Cache MCR
-        if: ${{ matrix.os != 'ubuntu-22.04' }}
-        id: cache-mcr
-        uses: actions/cache@v4
-        with:
-          path: mcr
-          key: ${{ runner.os }}-matlab-${{ env.MCRVER }}-mcr
-          lookup-only: true
-      - name: Cache gists
-        id: cache-gists
-        uses: actions/cache@v4
-        with:
-          path: gists
-          key: ${{ runner.os }}-gists
-          lookup-only: true
-      - name: Download gists 
-        if: ${{ steps.cache-gists.outputs.cache-hit != 'true' }}
-        run: |
-          mkdir -p gists
-          pip3 install requests
-          python3 gist_test_ctf.py --get --token=${{ secrets.GH_GIST_TOKEN }} --dir gists
-      - name: Install Mac MCR
-        if: ${{ matrix.os == 'macos-12' && steps.cache-mcr.outputs.cache-hit != 'true' }}
-        run: |
-          mkdir -p mcr
-          unzip -d . -q gists/pace_neutrons_installer.zip
-          sudo ./pace_neutrons_installer/Contents/MacOS/setup -mode silent -agreeToLicense yes
-          sleep 10
-          while [[ ! -z $(ps aux |grep installer | grep mathworks) ]]; do sleep 10; done
-          cp -r /Applications/MATLAB/MATLAB_Runtime/v98/* mcr/
-      - name: Install Win MCR
-        if: ${{ matrix.os == 'windows-2022' && steps.cache-mcr.outputs.cache-hit != 'true' }}
-        run: |
-          mkdir -p mcr
-          powershell -Command "gists\pace_neutrons_installer.exe -mode silent -agreeToLicense yes"
-          sleep 10
-          powershell -Command "while(Get-Process pace_neutrons_installer -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 10 }"
-          cp -r /c/Program\ Files/MATLAB/MATLAB\ Runtime/v98/* mcr/
-
   build_and_test:
     name: Build and test, ${{ matrix.os }}, py${{ matrix.pyver }}
-    needs: cache_matlab
     # OS strategy matrix must match key in JSONSTR.os_map above
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-13, macos-14]
+        os: [ubuntu-24.04, windows-2022, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -137,28 +87,24 @@ jobs:
           echo MLVER=$MLVER >> $GITHUB_ENV
           echo MLPREFIX=`echo $JSONSTR | jq ".os_map[\"${{ matrix.os }}\"].mlprefix" | sed s/\"//g` >> $GITHUB_ENV
           echo "HOSTDIRECTORY=`pwd`" >> $GITHUB_ENV
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            echo "MATLABEXECUTABLE=/usr/local/MATLAB/$MLVER/bin/matlab" >> $GITHUB_ENV;
-          else
-            echo "MATLABEXECUTABLE=`pwd`/mcr/bin/matlab" >> $GITHUB_ENV;
-          fi
-          env
       - name: Set up MATLAB
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
         uses: matlab-actions/setup-matlab@v2.3.0
         with:
           release: ${{ env.MLVER }}
-      - uses: actions/cache/restore@v4
-        if: ${{ matrix.os != 'ubuntu-22.04' }}
+          products: MATLAB_Compiler_SDK
+      - name: Set Matlab env
+        run: |
+          echo "MATLABEXECUTABLE=`which matlab`" >> $GITHUB_ENV;
+          env
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          path: mcr
-          key: ${{ runner.os }}-matlab-${{ env.MCRVER }}-mcr
-          fail-on-cache-miss: true
-      - uses: actions/cache/restore@v4
-        with:
-          path: gists
-          key: ${{ runner.os }}-gists
-          fail-on-cache-miss: true
+          cache-downloads: true
+      - name: Download gists 
+        run: |
+          $MAMBA_EXE create -n gistsenv -c conda-forge python=3.9 numpy requests
+          eval "$($MAMBA_EXE shell activate gistsenv)"
+          mkdir -p gists
+          python gist_test_ctf.py --get --token=${{ secrets.GH_GIST_TOKEN }} --dir gists
       - uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: ${{ env.CIBW }}
@@ -166,17 +112,13 @@ jobs:
             MATLABEXECUTABLE="${{ env.MLPREFIX }}${{ env.MATLABEXECUTABLE }}"
             HOSTDIRECTORY="${{ env.MLPREFIX }}${{ env.HOSTDIRECTORY }}"
           CIBW_BUILD_VERBOSITY: 1
-          MACOSX_DEPLOYMENT_TARGET: "10.15"
-      - uses: mamba-org/setup-micromamba@v1
-        with:
-          cache-downloads: true
       - name: Install wheels and run test
         run: |
           # set -e makes sure the script fails if any command in the loop fails
           set -e
           cp -f gists/* test/
           for pyver in $(echo $PYVERS | sed s/[\"\']//g); do
-            $MAMBA_EXE create -n py$pyver -c conda-forge python=$pyver numpy six
+            $MAMBA_EXE create -n py$pyver -c conda-forge python=$pyver numpy six requests
             eval "$($MAMBA_EXE shell activate py$pyver)"
             python -m pip install wheelhouse/*cp$(echo $pyver | sed s/\\.//)*
             cd test
@@ -188,14 +130,14 @@ jobs:
       - name: Upload release wheels
         if: ${{ github.event_name == 'release' }}
         run: |
-          pip3 install requests numpy
-          python3 release.py --notest --github --token=${{ secrets.GH_GIST_TOKEN }}
-      #- name: Setup tmate
-      #  if: ${{ failure() }}
-      #  uses: mxschmitt/action-tmate@v3
+          eval "$($MAMBA_EXE shell activate gistsenv)"
+          python release.py --notest --github --token=${{ secrets.GH_GIST_TOKEN }}
+      - name: Setup tmate
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}_artifacts.zip
           path: |
             wheelhouse/*
-            **/*.mex[awmaci]*64
+            **/*.mex*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       py_version:
         type: choice
-        options: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        options: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 concurrency :
   group: ${{ github.workflow }}-${{ github.ref == 'refs/head/main' && github.run_number || github.ref }}
@@ -29,7 +29,7 @@ env:
       "pyvers": {
         "push": ["3.8"],
         "pull_request": ["3.8"],
-        "release": ["3.7", "3.8", "3.9", "3.10", "3.11"],
+        "release": ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
         "workflow_dispatch": ["WORKFLOW_PYVER"]
       },
       "os_map": {
@@ -43,9 +43,14 @@ env:
           "tag": "win_amd64",
           "mlprefix": ""
         },
-        "macos-12": {
+        "macos-13": {
           "mlver": "R2020a",
           "tag": "macosx_x86_64",
+          "mlprefix": ""
+        },
+        "macos-14": {
+          "mlver": "R2020a",
+          "tag": "macosx_arm64",
           "mlprefix": ""
         }
       }
@@ -58,7 +63,7 @@ jobs:
     name: Create Matlab cache, ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +114,7 @@ jobs:
     # OS strategy matrix must match key in JSONSTR.os_map above
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -140,7 +145,7 @@ jobs:
           env
       - name: Set up MATLAB
         if: ${{ matrix.os == 'ubuntu-22.04' }}
-        uses: matlab-actions/setup-matlab@v1.2.4
+        uses: matlab-actions/setup-matlab@v2.3.0
         with:
           release: ${{ env.MLVER }}
       - uses: actions/cache/restore@v4
@@ -154,7 +159,7 @@ jobs:
           path: gists
           key: ${{ runner.os }}-gists
           fail-on-cache-miss: true
-      - uses: pypa/cibuildwheel@v2.17.0
+      - uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: ${{ env.CIBW }}
           CIBW_ENVIRONMENT: >-

--- a/gist_test_ctf.py
+++ b/gist_test_ctf.py
@@ -1,8 +1,7 @@
 import argparse, requests, json, os, base64
 
-FILES = ['test_R2020a.ctf', 'test_R2021a.ctf', 'pace_neutrons_installer.exe', 'pace_neutrons_installer.zip']
-GIST_ID = ['7389c37c89aed787c8a200c993fb67af', 'b595469518fbec7d9e293cf98bc123d6',
-           'd13ac4e315dc0e0b95506c2b8bb4ef2d', '6a1606ced1d38118ec0e8d230048f372']
+FILES = ['test_R2024a.ctf']
+GIST_ID = ['2727bd8d670e42cd27e12d8c51582868']
 
 def main():
     parser = argparse.ArgumentParser()

--- a/src/load_matlab.cpp
+++ b/src/load_matlab.cpp
@@ -11,7 +11,11 @@ void *_loadlib(std::string path, const char* libname, std::string mlver) {
     if (mlver.length() > 0)
         mlver = "." + mlver;
 #if defined __APPLE__
-    void* lib = dlopen((path + "/maci64/" + libname + mlver + ".dylib").c_str(), RTLD_LAZY);
+    std::string arch = "/maci64/";
+#if defined __arm64__
+    arch = "/maca64/";
+#endif
+    void* lib = dlopen((path + arch + libname + mlver + ".dylib").c_str(), RTLD_LAZY);
 #else
     void* lib = dlopen((path + "/glnxa64/" + libname + ".so" + mlver).c_str(), RTLD_LAZY);
 #endif


### PR DESCRIPTION
Fork of #32 

Update github-actions to work with new Mac runners. Using `macos-13` for `x86_64` and `macos-14` for `arm64`. Removed custom installers for Windows and Mac as `matlab-actions` now fully supports both platforms. Updated to use Matlab R2024a.

Thanks @MridulS for initial code.

TODO:

* R2024b is broken because a `typedef` has changed so the C++ code does not compile.
* Python 3.13 is broken because the internal structure of `numpy` arrays have changed (although it still builds, the test fails but CI still passes - need to change this...)