### PR TITLE
Bugfixes from 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# [v0.2.0](https://github.com/pace-neutrons/libpymcr/compare/v0.1.8...v0.2.0)
+
+## New Features
+
+Adds a convenience function to create Matlab `function_handle`s in Python using the "@" (matrix-multiplication) operator:
+
+```
+sqw_fun = m @ spinwobj.horace_sqw
+```
+
+Note that the LHS must be the Matlab gateway object (`m = libpymcr.Matlab()`) and the RHS must be a proxied method of a Matlab object.
+Also, note that Matlab syntax like `fun = @(x) x+1` is not valid in Python, and should be constructed as `m.str2func('@(x)x+1')`.
+
+## Bugfixes
+
+* Fix changed `mxArray` layout in R2023b and newer versions of Matlab, so that wrapping arrays work again.
+* Nested calls to Matlab in Python functions called from Matlab now results in a `RuntimeError` rather than just hanging.
+* Pressing `Ctrl+C` in Python will now interrupt Matlab execution (but will not be instantaneous)
+* Matlab outputs now don't have extraneous newlines and look more like in Matlab.
+
+
 # [v0.1.8](https://github.com/pace-neutrons/libpymcr/compare/v0.1.7...v0.1.8)
 
 ## Bugfixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ authors:
     given-names: "Gregory S."
     orcid: https://orcid.org/0000-0002-2787-8054
 title: "libpymcr"
-version: "0.1.8"
+version: "0.2.0"
 date-released: "2024-04-26"
 license: "GPL-3.0-only"
 repository: "https://github.com/pace-neutrons/libpymcr"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MACOSX_RPATH TRUE)
 set(CMAKE_CXX_STANDARD 11)
 set(CXX_STANDARD_REQUIRED 11)
 
-set(MINIMUM_PYBIND11_VERSION 2.10.1)
+set(MINIMUM_PYBIND11_VERSION 2.12.0)
 set(FETCH_PYBIND11_REPO https://github.com/pybind/pybind11)
 
 if (PYTHON_EXECUTABLE)
@@ -20,7 +20,7 @@ find_package(Python3 COMPONENTS Interpreter Development)
 # Use system pybind11 if it exists
 find_package(pybind11 ${MINIMUM_PYBIND11_VERSION} QUIET)
 if (pybind11_FOUND)
-  message(STATUS "pybind11 >= ${MINIMUM_PYBIND11_VERSION} found")
+  message(STATUS "pybind11 ${pybind11_VERSION} found")
 else()
   include(FetchContent)
   if (EXISTS "${FETCHCONTENT_BASE_DIR}/pybind11-src")

--- a/libpymcr/utils.py
+++ b/libpymcr/utils.py
@@ -66,7 +66,7 @@ def get_nret_from_dis(frame):
         return 1  # Probably in a multi-line call
 
 
-def get_nlhs(name):
+def get_nlhs(name=None):
     # Tries to get the number of return values for a named (Matlab) function
     # Assumes that it's called as a method of the `m` or Matlab() object
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ mcr_add_mex(
     SRC call_python.cpp type_converter.cpp load_matlab.cpp
 )
 target_include_directories(call_python PUBLIC ${PYTHON_INCLUDE_DIRS})
-target_include_directories(call_python PUBLIC "${pybind11_SOURCE_DIR}/include")
+target_include_directories(call_python PUBLIC ${pybind11_INCLUDE_DIR})
 ##target_link_libraries(call_python type_converter)
 ## Explicitly does not link with Matlab libraries (we will call them with dlopen etc)
 set_property(TARGET call_python PROPERTY LINK_LIBRARIES "")

--- a/src/libpymcr.cpp
+++ b/src/libpymcr.cpp
@@ -118,12 +118,12 @@ namespace libpymcr {
 
     // Constructor
     matlab_env::matlab_env(const std::u16string ctfname, std::string matlabroot, std::vector<std::u16string> options) {
-        _loadlibraries(matlabroot);
+        _MLVER = _loadlibraries(matlabroot);
         auto mode = matlab::cpplib::MATLABApplicationMode::IN_PROCESS;
         // Specify MATLAB startup options
         _app = matlab::cpplib::initMATLABApplication(mode, options);
         _lib = matlab::cpplib::initMATLABLibrary(_app, ctfname);
-        _converter = pymat_converter(pymat_converter::NumpyConversion::COPY);
+        _converter = pymat_converter(pymat_converter::NumpyConversion::WRAP, _MLVER);
         _in_evaluation = false;
     }
 

--- a/src/libpymcr.cpp
+++ b/src/libpymcr.cpp
@@ -53,7 +53,6 @@ namespace libpymcr {
         if (_in_evaluation) {
             throw std::runtime_error("Cannot call Matlab from a nested Python function.");
         }
-        _in_evaluation = true;
         const size_t nlhs = 0;
         // Clears the streams
         _m_output.get()->str(std::basic_string<char16_t>());
@@ -64,6 +63,7 @@ namespace libpymcr {
         size_t nargout = _parse_inputs(m_args, args, kwargs);
         // Release the GIL to call Matlab (PyBind automatically acquires GIL in all defined functions)
         py::gil_scoped_release gil_release;
+        _in_evaluation = true;
         try {
             if (nargout == 1) {
                 if (m_args.size() == 1) {
@@ -79,6 +79,7 @@ namespace libpymcr {
             _in_evaluation = false;
             throw;
         }
+        _in_evaluation = false;
         // Re-aquire the GIL
         py::gil_scoped_acquire gil_acquire;
         // Prints outputs and errors
@@ -107,7 +108,6 @@ namespace libpymcr {
         }
         // Now clear temporary Matlab arrays created from Numpy array data inputs
         _converter.clear_py_cache();
-        _in_evaluation = false;
         return retval;
     }
 

--- a/src/libpymcr.cpp
+++ b/src/libpymcr.cpp
@@ -40,7 +40,7 @@ namespace libpymcr {
                 error_already_set = true;
             }
             if(_m_output.get()->in_avail() > 0) {
-                py::print(_m_output.get()->str(), py::arg("flush")=true);
+                py::print(_m_output.get()->str(), py::arg("flush")=true, py::arg("end")="");
                 _m_output.get()->str(std::basic_string<char16_t>());
             }
             py::gil_scoped_release gil_release;

--- a/src/libpymcr.hpp
+++ b/src/libpymcr.hpp
@@ -23,6 +23,7 @@ namespace libpymcr {
         pymat_converter _converter;
         size_t _parse_inputs(std::vector<matlab::data::Array>& m_args, py::args py_args, py::kwargs& py_kwargs);
         template <class T> T evalloop(matlab::cpplib::FutureResult<T> resAsync);
+        bool _in_evaluation;
     public:
         py::object feval(const std::u16string &funcname, py::args args, py::kwargs& kwargs);
         py::object call(py::args args, py::kwargs& kwargs);

--- a/src/libpymcr.hpp
+++ b/src/libpymcr.hpp
@@ -24,6 +24,7 @@ namespace libpymcr {
         size_t _parse_inputs(std::vector<matlab::data::Array>& m_args, py::args py_args, py::kwargs& py_kwargs);
         template <class T> T evalloop(matlab::cpplib::FutureResult<T> resAsync);
         bool _in_evaluation;
+        double _MLVER;
     public:
         py::object feval(const std::u16string &funcname, py::args args, py::kwargs& kwargs);
         py::object call(py::args args, py::kwargs& kwargs);

--- a/src/load_matlab.cpp
+++ b/src/load_matlab.cpp
@@ -43,12 +43,15 @@ std::string _getMLversion(std::string mlroot) {
     }
     return _MLVERSTR;
 }
-void _loadlibraries(std::string matlabroot) {
+double _loadlibraries(std::string matlabroot) {
+    std::string mlver = _getMLversion(matlabroot);
     if (!_LIBCPPSHARED) {
         _LIBDATAARRAY = _loadlib(matlabroot + "/extern/bin/", "libMatlabDataArray");
-        _LIBCPPSHARED = _loadlib(matlabroot + "/runtime/", "libMatlabCppSharedLib", _getMLversion(matlabroot));
+        _LIBCPPSHARED = _loadlib(matlabroot + "/runtime/", "libMatlabCppSharedLib", mlver);
         _LIBMEX = _loadlib(matlabroot + "/bin/", "libmex");
     }
+    char *end;
+    return std::strtod(mlver.c_str(), &end);
 }
 void _checklibs() {
     if (!_LIBDATAARRAY || !_LIBCPPSHARED || !_LIBMEX) {

--- a/src/load_matlab.hpp
+++ b/src/load_matlab.hpp
@@ -23,7 +23,7 @@
 void *_loadlib(std::string path, const char* libname, std::string mlver="");
 void *_resolve(void* lib, const char* sym);
 std::string _getMLversion(std::string mlroot);
-void _loadlibraries(std::string matlabroot);
+double _loadlibraries(std::string matlabroot);
 
 void* mexGetFunctionImpl();
 void mexDestroyFunctionImpl(void* impl);

--- a/src/matlab_cpp_shared.hpp
+++ b/src/matlab_cpp_shared.hpp
@@ -28,8 +28,7 @@
 #include <algorithm>
 #include <future>
 #include <exception>
-#include <MatlabDataArray/CharArray.hpp>
-#include <MatlabDataArray/StructArray.hpp>
+#include "matlab_data_array.hpp"
 
 void runtime_create_session(char16_t** options, size_t size);
 void runtime_terminate_session();

--- a/src/matlab_data_array.hpp
+++ b/src/matlab_data_array.hpp
@@ -1,0 +1,62 @@
+/* Own copy of MatlabDataArray.hpp with only the functionality we need.
+ * This is to enable overrides of certain definitions.
+ * Matlab on github-hosted action runners for MacOS X and Windows.
+ */
+
+#include <MatlabDataArray/ArrayFactory.hpp>
+#include <MatlabDataArray/CharArray.hpp>
+#include <MatlabDataArray/MDArray.hpp>
+#include <MatlabDataArray/StructArray.hpp>
+#include <MatlabDataArray/TypedArray.hpp>
+
+#ifndef MARRAYFACTORY_HPP
+#define MARRAYFACTORY_HPP
+namespace matlab {
+    namespace data {
+        // The definition of the buffer_deleter_t type changed in R2024b when custom
+        // deleters were enabled. We define our own so as to handle all Matlab versions
+        template <typename T = void> using mbuffer_deleter_t = void(*)(T*);
+        template <typename T> using mbuffer_ptr_t = std::unique_ptr<T[], mbuffer_deleter_t<T>>;
+
+        // Subclass to overide the createBuffer method to have a consistent interface for <R2024b
+        class mArrayFactory : public ArrayFactory {
+        public:
+            template <typename T> mbuffer_ptr_t<T> createBuffer(size_t numberOfElements) {
+                void* buffer = nullptr;
+                mbuffer_deleter_t<> deleter = nullptr;
+                typedef int (*CreateBufferFcnPtr)(typename impl::ArrayFactoryImpl * impl, void** buffer,
+                                                  void (**deleter)(void*), int dataType, size_t numElements);
+                static const CreateBufferFcnPtr fcn =
+                    detail::resolveFunction<CreateBufferFcnPtr>(detail::FunctionType::CREATE_BUFFER);
+                detail::throwIfError(fcn(pImpl.get(), &buffer, &deleter,
+                                         static_cast<int>(GetArrayType<T>::type), numberOfElements));
+                return mbuffer_ptr_t<T>(static_cast<T*>(buffer), reinterpret_cast<mbuffer_deleter_t<T>>(deleter));
+            }
+            template <typename T> TypedArray<T> createArrayFromBuffer(ArrayDimensions dims, mbuffer_ptr_t<T> buffer, 
+                                                                      MemoryLayout memoryLayout = MemoryLayout::COLUMN_MAJOR) {
+                mbuffer_deleter_t<> deleter = reinterpret_cast<mbuffer_deleter_t<>>(buffer.get_deleter());
+                impl::ArrayImpl* impl = nullptr;
+                typedef int (*CreateArrayFromBufferV2FcnPtr)(typename impl::ArrayFactoryImpl * impl, int arrayType,
+                        size_t* dims, size_t numDims, void* buffer, void (*deleter)(void*), typename impl::ArrayImpl**, int memoryLayout);
+                static const CreateArrayFromBufferV2FcnPtr fcn = detail::resolveFunctionNoExcept<CreateArrayFromBufferV2FcnPtr>(
+                        detail::FunctionType::CREATE_ARRAY_FROM_BUFFER_V2);
+                if (fcn != nullptr) {
+                    detail::throwIfError(fcn(pImpl.get(), static_cast<int>(GetArrayType<T>::type), &dims[0],
+                                             dims.size(), buffer.release(), deleter, &impl, static_cast<int>(memoryLayout)));
+                } else {
+                // new version is not available; if asking for a row-major need to throw
+                    if (memoryLayout == MemoryLayout::ROW_MAJOR) {
+                        throw FeatureNotSupportedException(std::string("Row-major buffers require 2019a")); }
+                    typedef int (*CreateArrayFromBufferFcnPtr)(typename impl::ArrayFactoryImpl * impl, int arrayType, size_t* dims,
+                            size_t numDims, void* buffer, void (*deleter)(void*), typename impl::ArrayImpl**);
+                    static const CreateArrayFromBufferFcnPtr fcn = detail::resolveFunction<CreateArrayFromBufferFcnPtr>(
+                            detail::FunctionType::CREATE_ARRAY_FROM_BUFFER);
+                    detail::throwIfError(fcn(pImpl.get(), static_cast<int>(GetArrayType<T>::type), &dims[0],
+                                             dims.size(), buffer.release(), deleter, &impl));
+                }
+                return detail::Access::createObj<TypedArray<T>>(impl);
+            }
+        };
+    }
+}
+#endif // MARRAYFACTORY_HPP

--- a/src/matlab_mex.hpp
+++ b/src/matlab_mex.hpp
@@ -7,9 +7,9 @@
 //#include "mexAdapter.hpp"
 
 #include "load_matlab.hpp"
+#include "matlab_data_array.hpp"
 #include <cassert>
 #include <cstdlib>
-#include <MatlabDataArray/MDArray.hpp>
 
 #ifndef mex_hpp
 #define mex_hpp

--- a/src/type_converter.cpp
+++ b/src/type_converter.cpp
@@ -23,7 +23,11 @@ struct mxArray_header_2020a* _get_mxArray(Array arr, double mlver) {
     struct impl_header_col_major* m0 = reinterpret_cast<struct impl_header_col_major*>(imp);
     struct impl_header_col_major* m1 = reinterpret_cast<struct impl_header_col_major*>(m0->data_ptr);
 #if defined __APPLE__
-    return reinterpret_cast<struct mxArray_header_2020a*>(m1->data_ptr);
+    if (mlver > 10) {  // R2023b or newer
+        return reinterpret_cast<struct mxArray_header_2020a*>(m1->dims);
+    } else {
+        return reinterpret_cast<struct mxArray_header_2020a*>(m1->data_ptr);
+    }
 #else
     if (mlver > 10) {  // R2023b or newer
         return reinterpret_cast<struct mxArray_header_2020a*>(m1->mxArray2);

--- a/src/type_converter.hpp
+++ b/src/type_converter.hpp
@@ -2,11 +2,9 @@
 #define TYPECONVERTER_H
 
 #include "load_matlab.hpp"
+#include "matlab_data_array.hpp"
 #include <cstddef>
 using ssize_t = std::ptrdiff_t;
-
-#include <MatlabDataArray/TypedArray.hpp>
-#include <MatlabDataArray/ArrayFactory.hpp>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
@@ -159,15 +157,15 @@ namespace libpymcr {
         // Methods to convert from Python to Matlab
         template <typename T> Array raw_to_matlab(char *raw, size_t sz, std::vector<size_t> dims,
                                                   ssize_t *strides, int f_or_c_continuous,
-                                                  matlab::data::ArrayFactory &factory, PyObject* obj);
+                                                  matlab::data::mArrayFactory &factory, PyObject* obj);
         bool release_buffer(matlab::data::Array arr);
-        matlab::data::Array python_array_to_matlab(PyObject *result, matlab::data::ArrayFactory &factory);
-        template <typename T> Array fill_vec_from_pyobj(std::vector<PyObject*> &objs, matlab::data::ArrayFactory &factory);
-        CharArray python_string_to_matlab(PyObject *result, matlab::data::ArrayFactory &factory);
-        Array listtuple_to_cell(PyObject *result, matlab::data::ArrayFactory &factory);
-        StructArray python_dict_to_matlab(PyObject *result, matlab::data::ArrayFactory &factory);
-        matlab::data::Array wrap_python_function(PyObject *input, matlab::data::ArrayFactory &factory);
-        matlab::data::Array python_to_matlab_single(PyObject *input, matlab::data::ArrayFactory &factory);
+        matlab::data::Array python_array_to_matlab(PyObject *result, matlab::data::mArrayFactory &factory);
+        template <typename T> Array fill_vec_from_pyobj(std::vector<PyObject*> &objs, matlab::data::mArrayFactory &factory);
+        CharArray python_string_to_matlab(PyObject *result, matlab::data::mArrayFactory &factory);
+        Array listtuple_to_cell(PyObject *result, matlab::data::mArrayFactory &factory);
+        StructArray python_dict_to_matlab(PyObject *result, matlab::data::mArrayFactory &factory);
+        matlab::data::Array wrap_python_function(PyObject *input, matlab::data::mArrayFactory &factory);
+        matlab::data::Array python_to_matlab_single(PyObject *input, matlab::data::mArrayFactory &factory);
     public:
         void clear_py_cache();
         pymat_converter(NumpyConversion np_behaviour=NumpyConversion::COPY, double matlab_version=9.8);

--- a/src/type_converter.hpp
+++ b/src/type_converter.hpp
@@ -83,7 +83,10 @@ namespace libpymcr {
         void *unknown3;
         void *unknown4;
 #endif
-        void *mxArray;           // Pointer to mxArray in the *data_ptr struct
+        void *mxArray;           // Pointer to mxArray in the *data_ptr struct (R2020a-R2023a)
+        void *ptr1;              // Unknown function pointer in >R2023b (deleter?)
+        void *ptr2;              // Unknown function pointer in >R2023b
+        void *mxArray2;          // Pointer to mxArray in >R2023b
     };
  
     // Header for a (new-style) row-major array
@@ -143,6 +146,7 @@ namespace libpymcr {
         std::vector< std::pair<matlab::data::Array, PyObject*> > m_py_cache;
         PyTypeObject* m_py_matlab_wrapper_t;
         bool m_mex_flag;
+        double m_MLVERSION;
         // Methods to convert from Matlab to Python
         PyObject* is_wrapped_np_data(void* addr);
         template <typename T> PyObject* matlab_to_python_t (matlab::data::Array arr, dt<T>);
@@ -166,7 +170,7 @@ namespace libpymcr {
         matlab::data::Array python_to_matlab_single(PyObject *input, matlab::data::ArrayFactory &factory);
     public:
         void clear_py_cache();
-        pymat_converter(NumpyConversion np_behaviour=NumpyConversion::COPY);
+        pymat_converter(NumpyConversion np_behaviour=NumpyConversion::COPY, double matlab_version=9.8);
         ~pymat_converter();
         matlab::data::Array to_matlab(PyObject *input, bool mex_flag=false);
         PyObject* to_python(matlab::data::Array input);


### PR DESCRIPTION
Various bugfixes and new functionalities intended to be for v0.2 but merged now as there no effort to work on this further and a bugfix release is needed.

* Fix formating bug where a lot of newlines get added to the text (e.g. in the in progress ". . ." text which Horace prints)
* Update custom code to read `mxArray` to handle format change with R2023b
* Add handling of Python `KeyboardInterrupt` during Matlab processing
* Add guard to prevent a nested Python function calling Matlab (which previously causes a deadlock)
* Add routines to strip and recombine non-encoded files (e.g. `mex`) in a CTF archive
* Update code to handle numpy v2
* Update code to handle new Matlab buffer pointer syntax change with R2024b

In addition the following features were intended for v0.2 but need significantly more work:

* Ability to call Python from Matlab without using a mex file
   - This is needed because the current implementation sometimes results in a memory error (segmentation fault) when the app exits because of stack incompatibilities.
   - Initially the idea was to use an echo server in the `call.m` file and a corresponding server in the `libpymcr.cpp` code, but this needs a lot more work
   - Also explored trying to use internal APIs to initialise the mex file from the libpymcr side which would alleviate the stack incompatibilities but this requires some non-trivial reverse engineering of the code.
   - As such this feature is left for future releases.