### PR TITLE
RELEASE v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [v0.2.0](https://github.com/pace-neutrons/libpymcr/compare/v0.1.8...v0.2.0)
+# [v0.2.1](https://github.com/pace-neutrons/libpymcr/compare/v0.1.8...v0.2.1)
 
 ## New Features
 
@@ -19,6 +19,8 @@ Also, note that Matlab syntax like `fun = @(x) x+1` is not valid in Python, and 
 * Matlab outputs now don't have extraneous newlines and look more like in Matlab.
 * Update code to handle numpy v2
 * Update code to handle new Matlab buffer syntax change in R2024b
+* Refactor `call_python` to avoid ABI change between Python 3.11 and 3.12
+* Fix a GIL deadlock error when using `call_python` with new interrupt (`Ctrl+C`) mechanism.
 
 ## For Developers
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,7 +18,7 @@ authors:
     given-names: "Mridul"
     orcid: "https://orcid.org/0000-0002-0969-0437"
 title: "libpymcr"
-version: "0.2.0"
+version: "0.2.1"
 date-released: "2024-04-26"
 license: "GPL-3.0-only"
 repository: "https://github.com/pace-neutrons/libpymcr"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,27 +1,11 @@
-#add_library(type_converter OBJECT type_converter.cpp)
-#target_include_directories(type_converter PRIVATE ${Matlab_INCLUDE_DIRS})
-#target_include_directories(type_converter PRIVATE ${PYTHON_INCLUDE_DIRS})
-#target_include_directories(type_converter PRIVATE "${pybind11_SOURCE_DIR}/include")
-#set_property(TARGET type_converter PROPERTY POSITION_INDEPENDENT_CODE ON)
-
 pybind11_add_module(_libpymcr libpymcr.cpp type_converter.cpp load_matlab.cpp)
 target_include_directories(_libpymcr PRIVATE ${Matlab_INCLUDE_DIRS})
-#target_link_libraries(_libpymcr PUBLIC type_converter)
 
 mcr_add_mex(
     NAME call_python
-    SRC call_python.cpp type_converter.cpp load_matlab.cpp
+    SRC call_python.cpp load_matlab.cpp
 )
-target_include_directories(call_python PUBLIC ${PYTHON_INCLUDE_DIRS})
-target_include_directories(call_python PUBLIC ${pybind11_INCLUDE_DIR})
-##target_link_libraries(call_python type_converter)
-## Explicitly does not link with Matlab libraries (we will call them with dlopen etc)
+# Explicitly does not link with Matlab libraries (we will call them with dlopen etc)
 set_property(TARGET call_python PROPERTY LINK_LIBRARIES "")
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    target_link_libraries(call_python ${PYTHON_LIBRARIES})
-endif()
 # This is set automatically by setup.py but we don't want call_python.mex in the wheel
 set_property(TARGET call_python PROPERTY LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-
-#get_target_property(CALLPYTHON_LINKED_LIBS call_python LINK_LIBRARIES)
-#message("Libs linked to call_python: ${CALLPYTHON_LINKED_LIBS}")

--- a/src/call.m
+++ b/src/call.m
@@ -43,7 +43,7 @@ end
 function out = unwrap(in_obj)
     out = in_obj;
     if isstruct(in_obj) && isfield(in_obj, 'libpymcr_func_ptr')
-        out = @(varargin) call('_call_python', in_obj.libpymcr_func_ptr, varargin{:});
+        out = @(varargin) call('_call_python', in_obj.libpymcr_func_ptr, [in_obj.mex_func_ptr, in_obj.conv_ptr], varargin{:});
     elseif isa(in_obj, 'containers.Map') && in_obj.isKey('wrapped_oldstyle_class')
         out = in_obj('wrapped_oldstyle_class');
     elseif iscell(in_obj)
@@ -127,11 +127,12 @@ function out = call_python_m(varargin)
         end
     end
     fun_name = varargin{1};
-    [kw_args, remaining_args] = get_kw_args(varargin(2:end));
+    ptrs = varargin{2};
+    [kw_args, remaining_args] = get_kw_args(varargin(3:end));
     if ~isempty(kw_args)
         remaining_args = [remaining_args {struct('pyHorace_pyKwArgs', 1, kw_args{:})}];
     end
-    out = call_python(fun_name, remaining_args{:});
+    out = call_python(fun_name, ptrs, remaining_args{:});
     if ~iscell(out)
         out = {out};
     end

--- a/src/call_python.cpp
+++ b/src/call_python.cpp
@@ -1,88 +1,21 @@
 #include "matlab_mex.hpp"
-#include "type_converter.hpp"
-
-using namespace matlab::data;
-using matlab::mex::ArgumentList;
-namespace py = pybind11;
 
 // -------------------------------------------------------------------------------------------------------
 // Mex class to run Python function referenced in a global dictionary
 // -------------------------------------------------------------------------------------------------------
 
 class MexFunction : public matlab::mex::Function {
-
-    protected:
-        libpymcr::pymat_converter *_converter = nullptr;
-        py::tuple convMat2np(ArgumentList inputs, py::handle owner, size_t lastInd) {
-            // Note that this function must be called when we have the GIL
-            size_t narg = inputs.size() + lastInd;
-            py::tuple retval(narg);
-            for (size_t idx = 1; idx <= narg; idx++) {
-                retval[idx - 1] = _converter->to_python(inputs[idx]);
-            }
-            return retval;
-        }
-
     public:
-        void operator()(ArgumentList outputs, ArgumentList inputs) {
-            matlab::data::ArrayFactory factory;
+        void operator()(matlab::mex::ArgumentList outputs, matlab::mex::ArgumentList inputs) {
             if (inputs.size() < 1 || inputs[0].getType() != matlab::data::ArrayType::CHAR) {
-                throw std::runtime_error("Input must be reference to a Python function.");
-            }
+                throw std::runtime_error("Input must be reference to a Python function."); }
+            if (inputs.size() < 2 || inputs[1].getType() != matlab::data::ArrayType::UINT64) {
+                throw std::runtime_error("Second input must be pointer to the converter."); }
             matlab::data::CharArray key = inputs[0];
+            uintptr_t convfun = inputs[1][0];
+            uintptr_t conv_addr = inputs[1][1];
 
-            PyGILState_STATE gstate = PyGILState_Ensure();  // GIL{
-
-            if (_converter == nullptr) {
-                _converter = new libpymcr::pymat_converter(libpymcr::pymat_converter::NumpyConversion::WRAP);
-            }
-
-            py::module pyHoraceFn = py::module::import("libpymcr");
-            py::dict fnDict = pyHoraceFn.attr("_globalFunctionDict");
-            PyObject *fn_ptr = PyDict_GetItemString(fnDict.ptr(), key.toAscii().c_str());
-
-            if (PyCallable_Check(fn_ptr)) {
-                PyObject *result;
-                size_t endIdx = inputs.size() - 1;
-                try {
-                    try {
-                        const matlab::data::StructArray in_struct(inputs[endIdx]);
-                        const matlab::data::Array v = in_struct[0][matlab::data::MATLABFieldIdentifier("pyHorace_pyKwArgs")];
-                        PyObject *kwargs = _converter->to_python(inputs[endIdx]);
-                        PyDict_DelItemString(kwargs, "pyHorace_pyKwArgs");
-                        py::tuple arr_in = convMat2np(inputs, fn_ptr, -2);
-                        result = PyObject_Call(fn_ptr, arr_in.ptr(), kwargs);
-                    } catch (...) {
-                        py::tuple arr_in = convMat2np(inputs, fn_ptr, -1);
-                        result = PyObject_CallObject(fn_ptr, arr_in.ptr());
-                    }
-                } catch (...) {
-                }
-                if (result == NULL) {
-                    PyErr_Print();
-                    PyGILState_Release(gstate);
-                    throw std::runtime_error("Python function threw an error.");
-                }
-                else {
-                    try {
-                        outputs[0] = _converter->to_matlab(result, Py_REFCNT(result)==1);
-                    } catch ( const std::exception& e ) {
-                        Py_DECREF(result);
-                        PyGILState_Release(gstate);
-                        throw std::runtime_error(e.what());
-                    } catch (...) {
-                        Py_DECREF(result);
-                        PyGILState_Release(gstate);
-                        throw std::runtime_error("Error in converting outputs to Matlab");
-                    }
-                    Py_DECREF(result);
-                }
-            } else {
-                PyGILState_Release(gstate);
-                throw std::runtime_error("Python function is not callable.");
-            }
-
-            PyGILState_Release(gstate);  // GIL}
+            ((void(*)(const char *, uintptr_t, std::vector<matlab::data::Array>::iterator, size_t, matlab::data::Array *))convfun)
+                (key.toAscii().c_str(), conv_addr, inputs.begin(), inputs.size(), &outputs[0]);
         }
-
 };

--- a/src/call_python.cpp
+++ b/src/call_python.cpp
@@ -66,10 +66,14 @@ class MexFunction : public matlab::mex::Function {
                 else {
                     try {
                         outputs[0] = _converter->to_matlab(result, Py_REFCNT(result)==1);
-                    } catch (char *e) {
+                    } catch ( const std::exception& e ) {
                         Py_DECREF(result);
                         PyGILState_Release(gstate);
-                        throw std::runtime_error(e);
+                        throw std::runtime_error(e.what());
+                    } catch (...) {
+                        Py_DECREF(result);
+                        PyGILState_Release(gstate);
+                        throw std::runtime_error("Error in converting outputs to Matlab");
                     }
                     Py_DECREF(result);
                 }

--- a/src/libpymcr.cpp
+++ b/src/libpymcr.cpp
@@ -33,17 +33,24 @@ namespace libpymcr {
         while (status != std::future_status::ready) {
             status = resAsync.wait_for(period);
             // Prints outputs and errors
-            py::gil_scoped_acquire gil_acquire;
-            // Check if there is an interrupt on the Python side (needs GIL)
-            if (!error_already_set && PyErr_CheckSignals() != 0) {
-                resAsync.cancel();
-                error_already_set = true;
+#if PY_VERSION_HEX >= 0x030b00f0  // PyThreadState_GetUnchecked introduced in Python-3.13
+            PyThreadState* threadState = PyThreadState_GetUnchecked();
+#else
+            PyThreadState* threadState = _PyThreadState_UncheckedGet();
+#endif
+            if (threadState == NULL) {
+                py::gil_scoped_acquire gil_acquire;
+                // Check if there is an interrupt on the Python side (needs GIL)
+                if (!error_already_set && PyErr_CheckSignals() != 0) {
+                    resAsync.cancel();
+                    error_already_set = true;
+                }
+                if(_m_output.get()->in_avail() > 0) {
+                    py::print(_m_output.get()->str(), py::arg("flush")=true, py::arg("end")="");
+                    _m_output.get()->str(std::basic_string<char16_t>());
+                }
+                py::gil_scoped_release gil_release;
             }
-            if(_m_output.get()->in_avail() > 0) {
-                py::print(_m_output.get()->str(), py::arg("flush")=true, py::arg("end")="");
-                _m_output.get()->str(std::basic_string<char16_t>());
-            }
-            py::gil_scoped_release gil_release;
         }
         return resAsync.get();
     }
@@ -83,8 +90,8 @@ namespace libpymcr {
         // Re-aquire the GIL
         py::gil_scoped_acquire gil_acquire;
         // Prints outputs and errors
-        //if(_m_output.get()->in_avail() > 0) {
-        //    py::print(_m_output.get()->str(), py::arg("flush")=true); }
+        if(_m_output.get()->in_avail() > 0) {
+            py::print(_m_output.get()->str(), py::arg("flush")=true); }
         if(_m_error.get()->in_avail() > 0) {
             py::print(_m_error.get()->str(), py::arg("file")=py::module::import("sys").attr("stderr"), py::arg("flush")=true); }
         // Converts outputs to Python types

--- a/src/libpymcr.cpp
+++ b/src/libpymcr.cpp
@@ -33,7 +33,7 @@ namespace libpymcr {
         while (status != std::future_status::ready) {
             status = resAsync.wait_for(period);
             // Prints outputs and errors
-#if PY_VERSION_HEX >= 0x030b00f0  // PyThreadState_GetUnchecked introduced in Python-3.13
+#if PY_VERSION_HEX >= 0x030d00f0  // PyThreadState_GetUnchecked introduced in Python-3.13
             PyThreadState* threadState = PyThreadState_GetUnchecked();
 #else
             PyThreadState* threadState = _PyThreadState_UncheckedGet();

--- a/src/load_matlab.hpp
+++ b/src/load_matlab.hpp
@@ -17,7 +17,7 @@
 #include <dlfcn.h>
 #endif
 
-#include "type_converter.hpp"
+#include "matlab_data_array.hpp"
 #include <fstream>
 
 void *_loadlib(std::string path, const char* libname, std::string mlver="");

--- a/src/matlab_data_array.hpp
+++ b/src/matlab_data_array.hpp
@@ -1,6 +1,5 @@
 /* Own copy of MatlabDataArray.hpp with only the functionality we need.
  * This is to enable overrides of certain definitions.
- * Matlab on github-hosted action runners for MacOS X and Windows.
  */
 
 #include <MatlabDataArray/ArrayFactory.hpp>

--- a/src/type_converter.cpp
+++ b/src/type_converter.cpp
@@ -354,9 +354,6 @@ matlab::data::Array pymat_converter::python_array_to_matlab(PyObject *result, ma
             else if (elsize == sizeof(std::complex<float>)) return factory.createScalar(*((std::complex<float>*)(arr->data)));
         }
     }
-    if (elsize == 0) {
-        throw std::runtime_error("Cannot convert heterogeneous numpy arrays to Matlab");
-    }
     std::vector<size_t> dims;
     size_t numel = 1;
     for (size_t id = 0; id < arr->nd; id++) {


### PR DESCRIPTION
The _real_ `0.2` release - fixes some bugs found when testing 0.2 pre-release with pace-python:

* Fix issue with parsing which files to include in version-independent part of `ctf` archive
* Fix GIL deadlock when using `call_python`
* Refactor `call_python` mex file to not link at all with Python - to overcome ABI changes between 3.11, 3.12 and 3.13. This allows us to ship a single `mex` file in the `ctf` rather than having one for each Python release. The main `call_python` code is now included in `libpymcr` rather than the `mex`-file.